### PR TITLE
Implement general_week_of_month to support the general week of month

### DIFF
--- a/lib/modules/week.rb
+++ b/lib/modules/week.rb
@@ -16,6 +16,30 @@ module WeekOfMonth
         return (i + 1) if o.include?(self.day)
       end
     end
+
+    # November week_split would like this
+    # [[nil, nil, nil, nil, nil, 1, 2],
+    #  [3, 4, 5, 6, 7, 8, 9],
+    #  [10, 11, 12, 13, 14, 15, 16],
+    #  [17, 18, 19, 20, 21, 22, 23],
+    #  [24, 25, 26, 27, 28, 29, 30]]
+    #
+    # The First Day of week decide its month of week.
+    # The W1 Nov should be Nov 3 - Nov 9
+    #
+    # Date.new(2012,11,15).general_week_of_month
+    #   => 2
+    #
+    # Date.new(2013,11,3).general_week_of_month
+    #   => 1
+    # @return [Fixnum]
+    def general_week_of_month
+      if week_split.first.first.nil?
+        week_of_month - 1
+      else
+        week_of_month
+      end
+    end
     
     # checks whether the given day lies in first week of month
     # Date.new(2012,11,1).first_week?

--- a/lib/test/modules/test_week.rb
+++ b/lib/test/modules/test_week.rb
@@ -33,7 +33,35 @@ class TestWeek < Test::Unit::TestCase
       assert_equal 5, klass.new(2013,12,31).week_of_month
     end
   end
-    
+
+   def test_general_week_of_month
+    [Date,Time].each do |klass|
+      assert_equal 4, klass.new(2013,1,31).general_week_of_month
+
+      assert_equal 4, klass.new(2013,2,28).general_week_of_month
+
+      assert_equal 5, klass.new(2013,3,31).general_week_of_month
+
+      assert_equal 4, klass.new(2013,4,30).general_week_of_month
+
+      assert_equal 4, klass.new(2013,5,31).general_week_of_month
+
+      assert_equal 5, klass.new(2013,6,30).general_week_of_month
+
+      assert_equal 4, klass.new(2013,7,31).general_week_of_month
+
+      assert_equal 4, klass.new(2013,8,31).general_week_of_month
+
+      assert_equal 5, klass.new(2013,9,30).general_week_of_month
+
+      assert_equal 4, klass.new(2013,10,31).general_week_of_month
+
+      assert_equal 4, klass.new(2013,11,30).general_week_of_month
+
+      assert_equal 5, klass.new(2013,12,31).general_week_of_month
+    end
+  end
+
   def test_week_split
     [Date,Time].each do |klass|
       object = klass.new(2013,1,10)


### PR DESCRIPTION
The General Week of Month is kind of different 

The First Day of week decide its month of week.  e.g.  Oct 27  - Nov 2  it is week month is Oct.

so
W3 Oct = Sun, Oct 20 through to Sat, Oct 26
W4 Oct = Sun, Oct 27 through to Sat, Nov 2
W1 Nov = Sun, Nov 3 through to Sat, Nov 9
W2 Nov = Sun, Nov 10 through to Sat, Nov 16
W3 Nov = Sun, Nov 17 through to Sat, Nov 23
W4 Nov = Sun, Nov 17 through to Sat, Nov 30
