### PR TITLE
Add first..last..weekday_in_month

### DIFF
--- a/lib/modules/constant.rb
+++ b/lib/modules/constant.rb
@@ -37,5 +37,7 @@ module WeekOfMonth
     # array of ordered days names starting from sunday and ending with saturday.
     DAYS_IN_SEQUENCE = %w(Sunday Monday Tuesday Wednesday Thursday Friday Saturday)
 
+    # array of ordered days names starting from sunday and ending with saturday.
+    WEEKS_IN_SEQUENCE = %w(Last First Second Third Fourth Fifth)
   end
 end

--- a/lib/modules/month.rb
+++ b/lib/modules/month.rb
@@ -64,5 +64,19 @@ module WeekOfMonth
       end
     end
     
+    # this code generates method named like 'first_monday_in_month',
+    # 'second_tuesday_in_month', 'last_friday_in_month' etc. for 
+    # first, second, third, fourth and last seven days of week
+    # Date.new(2014,11).third_saturday_in_month
+    #   => #<Date: 2014-11-15>
+    # @return [Date]
+    DAYS_IN_SEQUENCE.each_with_index do |day_name, i|
+      WEEKS_IN_SEQUENCE.each.with_index(-1) do |week_number, j|
+        method_name = "#{week_number.downcase}_#{day_name.downcase}_in_month".to_sym
+        define_method(method_name) do
+          self.class.new(year, month, week_split.map{|d| d[i] }.compact[j])
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Added functionality to generate methods like 'first_monday_in_month', 'second_tuesday_in_month', 'last_friday_in_month' etc. for [first, second, third, fourth, fifth and last]_[sunday, monday, tuesday, wednesday, thursday, friday, saturday]_in_month. These return a Date.

For instance, Date.new(2014,11).third_saturday_in_month will yield #<Date: 2014-11-15>