### PR TITLE
Correction on japanese translation

### DIFF
--- a/lib/modules/constant.rb
+++ b/lib/modules/constant.rb
@@ -19,8 +19,8 @@ module WeekOfMonth
                     4 => 'Vierte', 5 => 'Fünfte', 6 => 'Sechste', 7 => 'siebte'}
 
     # hash containing japanese words from one to seven
-    WEEK_OF_MONTH_IN_JAP = { 1 => '最初', 2 => '秒', 3 => 'サード',
-                    4 => '第4回', 5 => '第五', 6=> 'シックス', 7 =>  '第7' }
+    WEEK_OF_MONTH_IN_JAP = { 1 => '第一', 2 => '第二', 3 => '第三',
+                    4 => '第四', 5 => '第五', 6=> '第六', 7 =>  '第七' }
 
     # hash containing month name with days in that month(in non leap year)
     MONTH_WITH_DAY = { :january => 31, :february => 28, :march => 31,

--- a/lib/modules/constant.rb
+++ b/lib/modules/constant.rb
@@ -19,7 +19,7 @@ module WeekOfMonth
                     4 => 'Vierte', 5 => 'Fünfte', 6 => 'Sechste', 7 => 'siebte'}
 
     # hash containing japanese words from one to seven
-    WEEK_OF_MONTH_IN_JAP = { 1 => '第一', 2 => '第二', 3 => '第三',
+    WEEK_OF_MONTH_IN_JA = { 1 => '第一', 2 => '第二', 3 => '第三',
                     4 => '第四', 5 => '第五', 6=> '第六', 7 =>  '第七' }
 
     # hash containing month name with days in that month(in non leap year)

--- a/lib/test/modules/test_constant.rb
+++ b/lib/test/modules/test_constant.rb
@@ -42,10 +42,10 @@ class TestConstant < Test::Unit::TestCase
                      5 => 'Fünfte', 6 => 'Sechste',
                      7 => "siebte" }, klass::WEEK_OF_MONTH_IN_GER)
 
-      assert_equal({ 1=>'最初', 2 =>'秒',
-                                          3 =>'サード', 4=> '第4回',
-                     5 =>'第五', 6=> 'シックス' ,
-                     7 => "第7" } ,  klass::WEEK_OF_MONTH_IN_JAP)
+      assert_equal({ 1 => '第一', 2 => '第二',
+                     3 => '第三', 4 => '第四',
+                     5 => '第五', 6=> '第六',
+                     7 =>  '第七' } ,  klass::WEEK_OF_MONTH_IN_JAP)
 
       assert_equal({ :january => 1, :february => 2, :march => 3,
                      :april => 4, :may => 5, :june => 6, :july => 7,
@@ -62,4 +62,3 @@ class TestConstant < Test::Unit::TestCase
   end
 
 end
-

--- a/lib/test/modules/test_constant.rb
+++ b/lib/test/modules/test_constant.rb
@@ -15,7 +15,7 @@ class TestConstant < Test::Unit::TestCase
 
       assert klass::WEEK_OF_MONTH_IN_FR
 
-      assert klass::WEEK_OF_MONTH_IN_JAP
+      assert klass::WEEK_OF_MONTH_IN_JA
 
       assert klass::MONTH_WITH_DAY
 
@@ -45,7 +45,7 @@ class TestConstant < Test::Unit::TestCase
       assert_equal({ 1 => '第一', 2 => '第二',
                      3 => '第三', 4 => '第四',
                      5 => '第五', 6=> '第六',
-                     7 =>  '第七' } ,  klass::WEEK_OF_MONTH_IN_JAP)
+                     7 =>  '第七' } ,  klass::WEEK_OF_MONTH_IN_JA)
 
       assert_equal({ :january => 1, :february => 2, :march => 3,
                      :april => 4, :may => 5, :june => 6, :july => 7,

--- a/lib/test/modules/test_week.rb
+++ b/lib/test/modules/test_week.rb
@@ -146,14 +146,14 @@ class TestWeek < Test::Unit::TestCase
     end
   end
 
-  def test_week_of_month_in_jap
+  def test_week_of_month_in_ja
     [Date,Time].each do |klass|
-      assert_equal '第一', klass.new(2012,12,1).week_of_month_in_jap
-      assert_equal '第二', klass.new(2012,12,4).week_of_month_in_jap
-      assert_equal '第三', klass.new(2012,12,9).week_of_month_in_jap
-      assert_equal '第四', klass.new(2012,12,16).week_of_month_in_jap
-      assert_equal '第五', klass.new(2012,12,24).week_of_month_in_jap
-      assert_equal '第六',  klass.new(2012,12,31).week_of_month_in_jap
+      assert_equal '第一', klass.new(2012,12,1).week_of_month_in_ja
+      assert_equal '第二', klass.new(2012,12,4).week_of_month_in_ja
+      assert_equal '第三', klass.new(2012,12,9).week_of_month_in_ja
+      assert_equal '第四', klass.new(2012,12,16).week_of_month_in_ja
+      assert_equal '第五', klass.new(2012,12,24).week_of_month_in_ja
+      assert_equal '第六',  klass.new(2012,12,31).week_of_month_in_ja
     end
   end
 

--- a/lib/test/modules/test_week.rb
+++ b/lib/test/modules/test_week.rb
@@ -148,12 +148,12 @@ class TestWeek < Test::Unit::TestCase
 
   def test_week_of_month_in_jap
     [Date,Time].each do |klass|
-      assert_equal '最初', klass.new(2012,12,1).week_of_month_in_jap
-      assert_equal '秒', klass.new(2012,12,4).week_of_month_in_jap
-      assert_equal 'サード', klass.new(2012,12,9).week_of_month_in_jap
-      assert_equal '第4回', klass.new(2012,12,16).week_of_month_in_jap
+      assert_equal '第一', klass.new(2012,12,1).week_of_month_in_jap
+      assert_equal '第二', klass.new(2012,12,4).week_of_month_in_jap
+      assert_equal '第三', klass.new(2012,12,9).week_of_month_in_jap
+      assert_equal '第四', klass.new(2012,12,16).week_of_month_in_jap
       assert_equal '第五', klass.new(2012,12,24).week_of_month_in_jap
-      assert_equal 'シックス',  klass.new(2012,12,31).week_of_month_in_jap
+      assert_equal '第六',  klass.new(2012,12,31).week_of_month_in_jap
     end
   end
 

--- a/week_of_month.gemspec
+++ b/week_of_month.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.version       = WeekOfMonth::VERSION
   s.summary       = 'Week of month!'
   s.description   = 'Its gives you week_of_month method on date and time objects, that returns week of the month.'
-  s.authors       =  %w(Sachin87 Tommyixi Matt-- berikin pablorusso AstonJ swapnilchincholkar hitendrasingh ilake)
+  s.authors       =  %w(Sachin87 Tommyixi Matt-- berikin pablorusso AstonJ swapnilchincholkar hitendrasingh ilake fursich)
   s.email         = %w(sachin@railsdeveloper.in sachin.y87@gmail.com singhsachin87@yahoo.com)
   s.homepage      = 'https://github.com/sachin87/week-of-month'
   s.files         = `git ls-files`.split("\n").sort


### PR DESCRIPTION
@sachin87 
Hi, First of all ** a big thanks ** for the useful gem from one of your frequent users :)

A suggestion for two small changes , including two commits shown below.

### correction in Japanese 
Corrected a few weird expressions in Japanese.

(for instance, `second` has been translated as `秒 (byo)`, which stands for `1/60 of a miniute`, etc :) )

### country notions
Modified WEEK_OF_MONTH_IN_JAP to WEEK_OF_MONTH_IN_JA to align with commonly used I18n notions. (also I thought "jap" might sound slightly offensive to certain Japanese people)

You might prefer the constant to remain unchanged, so I'd respect the owners' call whether to pick this up. Each of the commits are individually green-tested with the updated test files.

Hope these make sense!